### PR TITLE
Just use the file name, not the full path

### DIFF
--- a/upload-to-release
+++ b/upload-to-release
@@ -34,7 +34,8 @@ fi
 
 # Build the Upload URL from the various pieces
 RELEASE_ID=$(jq --raw-output '.release.id' $GITHUB_EVENT_PATH)
-UPLOAD_URL="https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets?name=${1}"
+FILENAME=$(basename $1)
+UPLOAD_URL="https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets?name=${FILENAME}"
 echo "$UPLOAD_URL"
 
 # Upload the file


### PR DESCRIPTION
This PR fixes a bug that @cedrickring pointed out [in this comment](https://github.com/JasonEtco/upload-to-release/pull/3#issuecomment-464186143). We're using the fully qualified path (the first argument passed) as the name of the uploaded file, rather than the file's actual name. GitHub then transforms the string, so given a path like this:

```
/path/to/file.txt
```

It would upload that file as:

```
path.to.file.txt
```

Using `basename`, we now extract the name of the file from the full path and use it on the `name` query param.