### PR TITLE
Fix release ID not in GitHub event

### DIFF
--- a/upload-to-release
+++ b/upload-to-release
@@ -37,7 +37,7 @@ fi
 TAG_NAME=$(jq --raw-output ".ref" $GITHUB_EVENT_PATH | sed "s/refs\///g")
 RELEASES_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${TAG_NAME}"
 RELEASE_RESPONSE=$(curl -sSL -XGET -H "${AUTH_HEADER}" -H "${ACCEPT_HEADER}" ${RELEASES_URL})
-RELEASE_ID=$(echo ${resp} | jq .id | sed "s/\"//g")
+RELEASE_ID=$(echo ${RELEASE_RESPONSE} | jq .id | sed "s/\"//g")
 
 # Build the Upload URL from the various pieces
 FILENAME=$(basename $1)

--- a/upload-to-release
+++ b/upload-to-release
@@ -25,6 +25,7 @@ fi
 # Prepare the headers
 AUTH_HEADER="Authorization: token ${GITHUB_TOKEN}"
 CONTENT_LENGTH_HEADER="Content-Length: $(stat -c%s "${1}")"
+ACCEPT_HEADER="Accept: application/vnd.github.v3+json"
 
 if [[ -z "$2" ]]; then
   CONTENT_TYPE_HEADER="Content-Type: ${2}"
@@ -32,8 +33,13 @@ else
   CONTENT_TYPE_HEADER="Content-Type: application/zip"
 fi
 
+# Get the release ID from the tag name
+TAG_NAME=$(jq --raw-output ".ref" $GITHUB_EVENT_PATH | sed "s/refs\///g")
+RELEASES_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${TAG_NAME}"
+RELEASE_RESPONSE=$(curl -sSL -XGET -H "${AUTH_HEADER}" -H "${ACCEPT_HEADER}" ${RELEASES_URL})
+RELEASE_ID=$(echo ${resp} | jq .id | sed "s/\"//g")
+
 # Build the Upload URL from the various pieces
-RELEASE_ID=$(jq --raw-output '.release.id' $GITHUB_EVENT_PATH)
 FILENAME=$(basename $1)
 UPLOAD_URL="https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets?name=${FILENAME}"
 echo "$UPLOAD_URL"

--- a/upload-to-release
+++ b/upload-to-release
@@ -16,7 +16,7 @@ if [[ -z "$1" ]]; then
 fi
 
 # Only upload to non-draft releases
-IS_DRAFT=$(jq --raw-output '.release.draft' $GITHUB_EVENT_PATH)
+IS_DRAFT=$(jq --raw-output ".release.draft" $GITHUB_EVENT_PATH)
 if [ "$IS_DRAFT" = true ]; then
   echo "This is a draft, so nothing to do!"
   exit 0


### PR DESCRIPTION
~~For new GitHub actions, it seems the release ID is not in the event json supplied to the action.~~ This pull request would change the upload script to retrieve the release ID from the API via the tag name.

Full disclousre: I haven't had a chance to properly test this yet - it may not completly work.

**Update: Turns out I can't read documentation 😂 I've solved my issue and this PR is not needed. However, if you want to use it as a basis for uploading from other event types - go for it**