### PR TITLE
Add `-f` flag to curl command

### DIFF
--- a/upload-to-release
+++ b/upload-to-release
@@ -45,6 +45,7 @@ echo "$UPLOAD_URL"
 
 # Upload the file
 curl \
+  -f \
   -sSL \
   -XPOST \
   -H "${AUTH_HEADER}" \


### PR DESCRIPTION
Closes https://github.com/JasonEtco/upload-to-release/issues/15

This will make the action fail when the upload API call returns an error.

From https://curl.haxx.se/docs/manpage.html:
> -f, --fail
    (HTTP) Fail silently (no output at all) on server errors. This is mostly done to better enable scripts etc to better deal with failed attempts.

Tested locally:
```sh
$ curl -f https://api.github.com/non-existant-page || echo ok
curl: (22) The requested URL returned error: 404 Not Found
ok

$ curl -f https://api.github.com/ || echo ok
{
  "current_user_url": "https://api.github.com/user",
  "current_user_authorizations_html_url": "https://github.com/settings/connections/applications{/client_id}",
  "authorizations_url": "https://api.github.com/authorizations",
...
}
```