### PR TITLE
Allow filename to be a glob pattern

### DIFF
--- a/upload-to-release
+++ b/upload-to-release
@@ -45,6 +45,11 @@ fi
 UPLOAD_URL="https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets?name=${FILENAME}"
 echo "$UPLOAD_URL"
 
+# List files being uploaded
+for file in $FILENAME; do
+  echo Uploading "${file##*/}"
+done
+
 # Upload the file
 curl \
   -f \

--- a/upload-to-release
+++ b/upload-to-release
@@ -22,9 +22,12 @@ if [ "$IS_DRAFT" = true ]; then
   exit 0
 fi
 
+# Expand the filename to allow for glob pattern
+FILENAME=$(basename $1)
+
 # Prepare the headers
 AUTH_HEADER="Authorization: token ${GITHUB_TOKEN}"
-CONTENT_LENGTH_HEADER="Content-Length: $(stat -c%s "${1}")"
+CONTENT_LENGTH_HEADER="Content-Length: $(stat -c%s "${FILENAME}")"
 
 if [[ -z "$2" ]]; then
   CONTENT_TYPE_HEADER="Content-Type: ${2}"
@@ -39,7 +42,6 @@ if [[ -z "${RELEASE_ID}" ]]; then
   exit 1
 fi
 
-FILENAME=$(basename $1)
 UPLOAD_URL="https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets?name=${FILENAME}"
 echo "$UPLOAD_URL"
 
@@ -51,5 +53,5 @@ curl \
   -H "${AUTH_HEADER}" \
   -H "${CONTENT_LENGTH_HEADER}" \
   -H "${CONTENT_TYPE_HEADER}" \
-  --upload-file "${1}" \
+  --upload-file "${FILENAME}" \
   "${UPLOAD_URL}"


### PR DESCRIPTION
This again attempts to do what #7 was doing. I have added an additional commit which will print the name of files stored FILENAME variable as it was requested in the [comment](https://github.com/JasonEtco/upload-to-release/pull/7#discussion_r317374946).