### PR TITLE
Fix default content-type overriding provided content-type

### DIFF
--- a/upload-to-release
+++ b/upload-to-release
@@ -27,9 +27,9 @@ AUTH_HEADER="Authorization: token ${GITHUB_TOKEN}"
 CONTENT_LENGTH_HEADER="Content-Length: $(stat -c%s "${1}")"
 
 if [[ -z "$2" ]]; then
-  CONTENT_TYPE_HEADER="Content-Type: ${2}"
-else
   CONTENT_TYPE_HEADER="Content-Type: application/zip"
+else
+  CONTENT_TYPE_HEADER="Content-Type: ${2}"
 fi
 
 # Build the Upload URL from the various pieces


### PR DESCRIPTION
I found that currently:
- When the User sets the content-type, it is overridden with `application/json`.
- When the User doesn't set the content-type, no content-type is set in the request header resulting in the api returning `400 Bad Request`.

This pull request swaps the if condition around so that:
- When the User sets the content-type, the user set content-type is used in the request header.
- When the User doesn't set the content-type, `application/json` is set as the content-type in the request header.